### PR TITLE
Predefined URL in `avatar` to prevent error

### DIFF
--- a/cogs/user_info.py
+++ b/cogs/user_info.py
@@ -16,6 +16,7 @@ class UserInfo(utils.Cog):
         """
 
         target = target or ctx.author
+        url = None
         if isinstance(target, (discord.User, discord.Member)):
             url = target.avatar_url
         elif isinstance(target, (discord.Emoji, discord.PartialEmoji)):


### PR DESCRIPTION
Command raised an exception: UnboundLocalError: local variable 'url' referenced before assignment