### PR TITLE
Removed feature that stops users from quoting themselves

### DIFF
--- a/cogs/quote_commands.py
+++ b/cogs/quote_commands.py
@@ -85,11 +85,6 @@ class QuoteCommands(vbu.Cog):
         if len(set([i.author.id for i in messages])) != 1:
             return {'success': False, 'message': "You can only quote one person at a time."}
 
-        # Make sure they're not quoting themself
-        message_author = messages[0].author
-        if ctx.author.id == message_author.id and allow_self_quote is False and ctx.author.id not in self.bot.owner_ids:
-            return {'success': False, 'message': "You can't quote yourself :/"}
-
         # Return an embed
         with vbu.Embed(use_random_colour=True) as embed:
             embed.set_author_to_user(user)

--- a/cogs/quote_commands.py
+++ b/cogs/quote_commands.py
@@ -88,7 +88,9 @@ class QuoteCommands(vbu.Cog):
         # Make sure they're not quoting themself if there are no reactions needed
         message_author = messages[0].author
         reactions_needed = self.bot.guild_settings[ctx.guild.id]['quote_reactions_needed']
-        if reactions_needed and ctx.author.id == message_author.id and allow_self_quote is False and ctx.author.id not in self.bot.owner_ids:
+        if ctx.author.id not in self.bot.owner_id:
+            pass
+        elif ctx.author.id == message_author.id and (reactions_needed or allow_self_quote is False):
             return {'success': False, 'message': "You can't quote yourself when there's no vote :/"}
 
         # Return an embed


### PR DESCRIPTION
Removed feature that stops users from quoting themselves, since quotes are only accepted if they have enough votes. No point in stopping a user from quoting themselves