### PR TITLE
Change `screenshotmessage`'s `user` type to `Member`

### DIFF
--- a/cogs/user_info.py
+++ b/cogs/user_info.py
@@ -121,7 +121,7 @@ class UserInfo(vbu.Cog):
 
     @commands.command(aliases=["fakemessage"])
     @commands.guild_only()
-    async def screenshotmessage(self, ctx: vbu.Context, user: typing.Union[discord.Member, discord.User], *, content: typing.Union[str, discord.Message]):
+    async def screenshotmessage(self, ctx: vbu.Context, user: discord.Member, *, content: typing.Union[str, discord.Message]):
         """
         Create a log of chat.
         """


### PR DESCRIPTION
The previous type, `Union[Member, User]`, doesn't get picked up correctly by vbu's slash commands converter as a user option, so I've changed it to only `Member` since it's a guildonly command and the chances of encountering the `User` type is unlikely. There may be a legitimate reason for having it as a `Union`, and if so, this issue could potentially be fixed on the vbu side of things.