### PR TITLE
Add Image and URLs to nuget command

### DIFF
--- a/cogs/library_docs.py
+++ b/cogs/library_docs.py
@@ -654,16 +654,35 @@ class LibraryDocs(vbu.Cog):
                 await ctx.send("Something went wrong, try again later...")
                 return
             data = await e.json()
-
+        buttontuples = []
         # make a lil embed
         with vbu.Embed(use_random_colour=True) as embed:
             if data['data']:
                 embed.set_author(name=data['data'][0]['title'], url=f"https://www.nuget.org/packages/{data['data'][0]['id']}")
                 embed.description = data['data'][0]['description']
+                # cut here if removing image support
+                if data['data'][0]['iconUrl']:
+                     embed.set_thumbnail(data['data'][0]['iconUrl'])
+                # cut here if removing image support
+                if data['data'][0]['projectUrl']:
+                    buttontuples.append(('Project URL', data['data'][0]['projectUrl']))
+                if data['data'][0]['licenseUrl']:
+                    buttontuples.append(('License URL', data['data'][0]['licenseUrl']))
+                buttontuples.append(('Download URL', f"https://www.nuget.org/api/v2/package/{data['data'][0]['id']}/{data['data'][0]['version']}"))
+                buttontuples.append(('Nuget package explorer', f"https://nuget.info/packages/{data['data'][0]['id']}/{data['data'][0]['version']}"))
+                buttontuples.append(('Fuget package explorer', f"https://www.fuget.org/packages/{data['data'][0]['id']}/{data['data'][0]['version']}"))
             else:
                 await ctx.send(f"I could not find anything for `{package_name}` :c")
                 return
-        await ctx.send(embed=embed)
+        buttons=[]
+        if (len(buttontuples)!=0):
+            for info in buttontuples:
+                buttons.append(discord.ui.Button(
+                    label=info[0],
+                    url=info[1],
+                    style=discord.ui.ButtonStyle.link))
+        components = discord.ui.MessageComponents.add_buttons_with_rows(*buttons)
+        await ctx.send(embed=embed, components=components)
 
     @commands.command(
         application_command_meta=commands.ApplicationCommandMeta(


### PR DESCRIPTION
This commit modifies cogs/library_docs.py by adding link buttons that allow the user to go to the projects URL if applicable, to see the license's URL if applicable, the download URL for the latest version and use the Nuget and Fuget package explorers, it also modifies the embed generation code to include an icon of the package if applicable.
Before:  
![image](https://user-images.githubusercontent.com/46320280/190725093-57f61958-b1e7-492b-9ab9-1e80856a40b9.png)
After:  
![image](https://user-images.githubusercontent.com/46320280/190725054-9a94b791-6935-4c26-b136-0ca25b393339.png)  
In the future it would be nice to include a link to the source repository if applicable but it appears that is sent through a different api url (https://api.nuget.org/v3-flatcontainer/{id}/{version}/{id}.nuspec for future reference if needed) 
This edit has been tested on a **different VBU based** bot running on the latest pypi version of VBU at the time of writing.  
A test on an apple.py fork may not be needed as this change only impacts the nuget command but it would be preferred to test on an apple.py fork instead of just YOLOing it.   
If the icon support needs to be removed (for any reason) just follow the comments.  
Also if you have read this so far you might want to consider using an automated code formatter to reformat the new code.