### PR TITLE
Dotnet rtfm fix

### DIFF
--- a/cogs/library_docs.py
+++ b/cogs/library_docs.py
@@ -547,8 +547,6 @@ class LibraryDocs(vbu.Cog):
         params = {
             'api-version': '0.2',
             'search': obj,
-            'locale': 'en-us',
-            '$filter': "monikers/any(t: t eq 'net-5.0')",
         }
         headers = {
             'User-Agent': self.bot.user_agent,
@@ -559,7 +557,7 @@ class LibraryDocs(vbu.Cog):
             return await ctx.send("I couldn't find anything. Sorry.")
         embed = vbu.Embed(use_random_colour=True, description="")
         for i in data['results']:
-            embed.description += f"[`{i['displayName']}`]({i['url']})\n"
+            embed.description += f"[`{i['displayName']}`](https://learn.microsoft.com{i['url']})\n"
             if embed.description.count("\n") >= 8:
                 break
         return await ctx.send(embed=embed)


### PR DESCRIPTION
The problem: API now returns relative urls that do not contain the domain
The (maybe temporary) fix: adding the domain ourselves
Oh and btw this commit removes the dotnet 5 only api query because dotnet 6 is already out and other framework monikers like `xamarin-android-sdk-` exist (the filter might be readded if there is nothing to do in the future as a dropdown menu and stuff)
Before fix (NO LINKS):  
![image](https://user-images.githubusercontent.com/46320280/191929045-58136aef-a3f6-4770-b734-f57bf2905648.png)
After fix (Links):   
![image](https://user-images.githubusercontent.com/46320280/191929127-e108dee7-62c9-47ff-b99f-13d344e280a4.png)
