### PR TITLE
Fix nuget command for packages that do not have an icon

### DIFF
--- a/cogs/library_docs.py
+++ b/cogs/library_docs.py
@@ -659,12 +659,12 @@ class LibraryDocs(vbu.Cog):
                 embed.set_author(name=data['data'][0]['title'], url=f"https://www.nuget.org/packages/{data['data'][0]['id']}")
                 embed.description = data['data'][0]['description']
                 # cut here if removing image support
-                if data['data'][0]['iconUrl']:
+                if 'iconUrl' in data['data'][0].keys() and data['data'][0]['iconUrl']:
                      embed.set_thumbnail(data['data'][0]['iconUrl'])
                 # cut here if removing image support
-                if data['data'][0]['projectUrl']:
+                if 'projectUrl' in data['data'][0].keys() and data['data'][0]['projectUrl']:
                     buttontuples.append(('Project URL', data['data'][0]['projectUrl']))
-                if data['data'][0]['licenseUrl']:
+                if 'licenseUrl' in data['data'][0].keys() and data['data'][0]['licenseUrl']:
                     buttontuples.append(('License URL', data['data'][0]['licenseUrl']))
                 buttontuples.append(('Download URL', f"https://www.nuget.org/api/v2/package/{data['data'][0]['id']}/{data['data'][0]['version']}"))
                 buttontuples.append(('Nuget package explorer', f"https://nuget.info/packages/{data['data'][0]['id']}/{data['data'][0]['version']}"))


### PR DESCRIPTION
This PR should fix the nuget command for packages that do not have an icon, or do not have a project url or do not have a license url  
I am the one to blame for this issue in the first place (had no clue python would throw a keyerror instead of returning null)
Before:  
![image](https://user-images.githubusercontent.com/46320280/202304971-7a9f2592-2523-4e78-a19a-a6b6c78a0a3a.png)
![image](https://user-images.githubusercontent.com/46320280/202306439-360bdb9c-a611-42a6-bdcb-491eb9ee08ad.png)
![image](https://user-images.githubusercontent.com/46320280/202307321-f737ef37-effa-4455-aa4b-016742915a64.png)

After:  
![image](https://user-images.githubusercontent.com/46320280/202305071-bfe56110-0550-4cf9-ba2f-5d23588bbbb0.png)
![image](https://user-images.githubusercontent.com/46320280/202306492-117a3f03-0145-4e91-ba6d-6e6662539015.png)
![image](https://user-images.githubusercontent.com/46320280/202307382-c940cc93-9ec3-4ca7-bce4-ee1b2de4c1cf.png)

Tested on a VBU bot running Python 3.11.0, Novus 0.2.1a3966+g5e29ad32  (via normal text commands)
Your milage might vary, but if it does do let me know because I'm probably the only person that uses this command and the dotnet rtfm command (and that would like for them to remain functional)  
You should still test the PR before merging even if I believe I solved the issues I was experiencing.